### PR TITLE
Fixes to send_nrdp clients

### DIFF
--- a/clients/send_nrdp.py
+++ b/clients/send_nrdp.py
@@ -16,6 +16,9 @@
 #  - Added file argument to allow XML results to be read from file
 #  - Replaced optparse with argparse so help text can include newline
 #    characters, allowing for better formatting.
+# 2017-09-26 Troy Lea aka BOX293
+#  - Made sure url ends with a / before posting
+
 
 import argparse, sys, urllib, cgi
 from xml.dom.minidom import parseString
@@ -89,7 +92,7 @@ printf \"<hostname>\\t<service>\\t<state>\\t<output>\\n\"\n")
             sys.exit()
         except Exception, e:
             sys.exit(e)
-
+        
     def getText(self, nodelist):
         rc = []
         for node in nodelist:
@@ -98,6 +101,10 @@ printf \"<hostname>\\t<service>\\t<state>\\t<output>\\n\"\n")
         return ''.join(rc)
 
     def post_data(self, url, token, xml):
+        # Make sure URL ends with a /
+        if not url.endswith('/'):
+            url += '/'
+        
         params = urllib.urlencode({'token': token.strip(), 'cmd': 'submitcheck', 'XMLDATA': xml});
         opener = urllib.FancyURLopener()
         try:

--- a/clients/send_nrdp.py
+++ b/clients/send_nrdp.py
@@ -12,44 +12,80 @@
 #    run as a cron job or if being used as a nagios command like
 #    obsessive compulsive ... "if not sys.stdin.isatty():" was the
 #    reason why.
+# 2017-09-25 Troy Lea aka BOX293
+#  - Added file argument to allow XML results to be read from file
+#  - Replaced optparse with argparse so help text can include newline
+#    characters, allowing for better formatting.
 
-
-import optparse, sys, urllib, cgi
-from xml.dom.minidom  import parseString
-
+import argparse, sys, urllib, cgi
+from xml.dom.minidom import parseString
 
 class send_nrdp:
-    options = [
-        optparse.make_option('-u', '--url', action="store",
-            dest="url", help="** REQUIRED ** The URL used to access the remote NRDP agent."),
-        optparse.make_option('-t', '--token', action="store",
-            dest="token", help="** REQUIRED ** The authentication token used to access the remote NRDP agent."),
-        optparse.make_option('-H', '--hostname', action="store",
-            dest="hostname", help="The name of the host associated with the passive host/service check result."),
-        optparse.make_option('-s', '--service', action="store",
-            dest="service", help="For service checks, the name of the service associated with the passive check result."),
-        optparse.make_option('-S', '--state', action="store",
-            dest="state", help="An integer indicating the current state of the host or service."),
-        optparse.make_option('-o', '--output', action="store",
-            dest="output", help="Text output to be sent as the passive check result. Newlines should be encoded with encoded newlines (\\n)."),
-        optparse.make_option('-f', '--file', action="store",
-            dest="file", help="-f /full/path/to/file\nThis file will be sent to the NRDP server specified in -u\nThe file should be an XML file in the following format\n##################################################\n<?xml version='1.0'?>\n<checkresults>\n  <checkresult type=\"host\" checktype=\"1\">\n    <hostname>YOUR_HOSTNAME</hostname>\n    <state>0</state>\n    <output>OK|perfdata=1.00;5;10;0</output>\n  </checkresult>\n  <checkresult type=\"service\" checktype=\"1\">\n    <hostname>YOUR_HOSTNAME</hostname>\n    <servicename>YOUR_SERVICENAME</servicename>\n    <state>0</state>\n    <output>OK|perfdata=1.00;5;10;0</output>\n  </checkresult>\n</checkresults>\n##################################################"),
-        optparse.make_option('-d', '--delim', action="store",
-            dest="delim", help="With only the required parameters send_nrdp.py is capable of processing data piped to it either from a file or other process. By default, we use t as the delimiter however this may be specified with the -d option data should be in the following formats one entry per line."),
-        optparse.make_option('-c', '--checktype', action="store",
-            dest="checktype", help="1 for passive 0 for active")
-    ]
-
     def run(self):
-        parser = optparse.OptionParser(option_list=self.options)
-        (options, args) = parser.parse_args()
-
+        parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+        
+        parser.add_argument('-u', '--url', action="store",
+            dest="url", help="\
+** REQUIRED ** The URL used to access the remote NRDP agent.")
+        parser.add_argument('-t', '--token', action="store",
+            dest="token", help="\
+** REQUIRED ** The authentication token used to access the\n\
+remote NRDP agent.")
+        parser.add_argument('-H', '--hostname', action="store",
+            dest="hostname", help="\
+The name of the host associated with the passive host/service\n\
+check result.")
+        parser.add_argument('-s', '--service', action="store",
+            dest="service", help="\
+For service checks, the name of the service associated with the\n\
+passive check result.")
+        parser.add_argument('-S', '--state', action="store",
+            dest="state", help="\
+An integer indicating the current state of the host or service.")
+        parser.add_argument('-o', '--output', action="store",
+            dest="output", help="\
+Text output to be sent as the passive check result.\n\
+Newlines should be encoded with encoded newlines (\\n).")
+        parser.add_argument('-f', '--file', action="store",
+            dest="file", help="\
+This file will be sent to the NRDP server specified in -u\n\
+The file should be an XML file in the following format:\n\
+##################################################\n\
+<?xml version='1.0'?>\n\
+<checkresults>\n\
+  <checkresult type=\"host\" checktype=\"1\">\n\
+    <hostname>YOUR_HOSTNAME</hostname>\n\
+    <state>0</state>\n\
+    <output>OK|perfdata=1.00;5;10;0</output>\n\
+  </checkresult>\n\
+  <checkresult type=\"service\" checktype=\"1\">\n\
+    <hostname>YOUR_HOSTNAME</hostname>\n\
+    <servicename>YOUR_SERVICENAME</servicename>\n\
+    <state>0</state>\n\
+    <output>OK|perfdata=1.00;5;10;0</output>\n\
+  </checkresult>\n\
+</checkresults>\n\
+##################################################")
+        parser.add_argument('-d', '--delim', action="store",
+            dest="delim", help="\
+With only the required parameters send_nrdp.py is capable of\n\
+processing data piped to it either from a file or other process.\n\
+By default, we use t (\\t) as the delimiter however this may be\n\
+specified with the -d option data should be in the following\n\
+formats of one entry per line:\n\
+printf \"<hostname>\\t<state>\\t<output>\\n\"\n\
+printf \"<hostname>\\t<service>\\t<state>\\t<output>\\n\"\n")
+        parser.add_argument('-c', '--checktype', action="store",
+            dest="checktype", help="1 for passive 0 for active")
+        
+        options = parser.parse_args()
+	
         if not options.url:
             parser.error('You must specify a url.')
         if not options.token:
             parser.error('You must specify a token.')
         try:
-            self.setup(options, args)
+            self.setup(options)
             sys.exit()
         except Exception, e:
             sys.exit(e)
@@ -77,15 +113,15 @@ class send_nrdp:
             print "ERROR - NRDP Returned: "+self.getText(result.getElementsByTagName("message")[0].childNodes)
             sys.exit(1)
 
-    def setup(self, options, args):
+    def setup(self, options):
         if not options.delim:
             options.delim = "\t"
         if not options.checktype:
             options.checktype = "1"
-        xml="<?xml version='1.0'?>\n<checkresults>\n";
         
         # If only url and token have been provided then it is assumed that data is being piped
-        if not options.hostname and not options.state:
+        if not options.hostname and not options.state and not options.file:
+            xml="<?xml version='1.0'?>\n<checkresults>\n";
             for line in sys.stdin.readlines():
                 parts = line.split(options.delim)
                 if len(parts) == 4:
@@ -103,25 +139,32 @@ class send_nrdp:
                     xml += "</checkresult>"
                 xml += "</checkresults>"
         
-        # TODO add file option
-        #elif options.file:
-        #    xml += READ THE FILE
-        else:        
-            if options.hostname and options.state:
-                if options.service:
-                    xml += "<checkresult type='service' checktype='"+options.checktype+"'>"
-                    xml += "<hostname>"+cgi.escape(options.hostname,True)+"</hostname>"
-                    xml += "<servicename>"+cgi.escape(options.service,True)+"</servicename>"
-                    xml += "<state>"+options.state+"</state>"
-                    xml += "<output>"+cgi.escape(options.output,True)+"</output>"
-                    xml += "</checkresult>"
-                else:
-                    xml += "<checkresult type='host'  checktype='"+options.checktype+"'>"
-                    xml += "<hostname>"+cgi.escape(options.hostname,True)+"</hostname>"
-                    xml += "<state>"+options.state+"</state>"
-                    xml += "<output>"+cgi.escape(options.output,True)+"</output>"
-                    xml += "</checkresult>"
-                xml += "</checkresults>"
+        elif options.hostname and options.state:
+            xml="<?xml version='1.0'?>\n<checkresults>\n";
+            if options.service:
+                xml += "<checkresult type='service' checktype='"+options.checktype+"'>"
+                xml += "<hostname>"+cgi.escape(options.hostname,True)+"</hostname>"
+                xml += "<servicename>"+cgi.escape(options.service,True)+"</servicename>"
+                xml += "<state>"+options.state+"</state>"
+                xml += "<output>"+cgi.escape(options.output,True)+"</output>"
+                xml += "</checkresult>"
+            else:
+                xml += "<checkresult type='host'  checktype='"+options.checktype+"'>"
+                xml += "<hostname>"+cgi.escape(options.hostname,True)+"</hostname>"
+                xml += "<state>"+options.state+"</state>"
+                xml += "<output>"+cgi.escape(options.output,True)+"</output>"
+                xml += "</checkresult>"
+            xml += "</checkresults>"
+
+        elif options.file:
+            try:
+                file_handle = open(options.file, 'r')
+            except Exception, e:
+                print "Error opening file '"+options.file+"'"
+                sys.exit(e)
+            else:
+                xml = file_handle.read()
+                file_handle.close()
 
         self.post_data(options.url, options.token, xml)
 

--- a/clients/send_nrdp.py
+++ b/clients/send_nrdp.py
@@ -32,6 +32,8 @@ class send_nrdp:
             dest="state", help="An integer indicating the current state of the host or service."),
         optparse.make_option('-o', '--output', action="store",
             dest="output", help="Text output to be sent as the passive check result. Newlines should be encoded with encoded newlines (\\n)."),
+        optparse.make_option('-f', '--file', action="store",
+            dest="file", help="-f /full/path/to/file\nThis file will be sent to the NRDP server specified in -u\nThe file should be an XML file in the following format\n##################################################\n<?xml version='1.0'?>\n<checkresults>\n  <checkresult type=\"host\" checktype=\"1\">\n    <hostname>YOUR_HOSTNAME</hostname>\n    <state>0</state>\n    <output>OK|perfdata=1.00;5;10;0</output>\n  </checkresult>\n  <checkresult type=\"service\" checktype=\"1\">\n    <hostname>YOUR_HOSTNAME</hostname>\n    <servicename>YOUR_SERVICENAME</servicename>\n    <state>0</state>\n    <output>OK|perfdata=1.00;5;10;0</output>\n  </checkresult>\n</checkresults>\n##################################################"),
         optparse.make_option('-d', '--delim', action="store",
             dest="delim", help="With only the required parameters send_nrdp.py is capable of processing data piped to it either from a file or other process. By default, we use t as the delimiter however this may be specified with the -d option data should be in the following formats one entry per line."),
         optparse.make_option('-c', '--checktype', action="store",

--- a/clients/send_nrdp.sh
+++ b/clients/send_nrdp.sh
@@ -5,9 +5,14 @@
 # Copyright (c) 2010-2017 - Nagios Enterprises, LLC.
 # Written by: Scott Wilkerson (nagios@nagios.org)
 #
+# 2017-09-25 Troy Lea aka BOX293
+#  - Fixed script not working with arguments when run as a cron job
+#    or if being used as a nagios command like obsessive compulsive.
+#     ... "if [ ! -t 0 ]" was the reason why.
+
 
 PROGNAME=$(basename $0)
-RELEASE="Revision 0.5"
+RELEASE="Revision 0.6"
 
 print_release() {
     echo "$RELEASE"
@@ -217,9 +222,9 @@ if [ $host ]; then
     checkcount=1
 fi
 
-# Detect STDIN
+ # If only url and token have been provided then it is assumed that data is being piped
 ########################
-if [ ! -t 0 ]; then
+if [[ ! $host && ! $State ]]; then
     xml=""
     # we know we are being piped results
     IFS=$delim

--- a/clients/send_nrdp.sh
+++ b/clients/send_nrdp.sh
@@ -224,7 +224,7 @@ fi
 
  # If only url and token have been provided then it is assumed that data is being piped
 ########################
-if [[ ! $host && ! $State && ! $file ]]; then
+if [[ ! $host && ! $State && ! $file && ! $directory ]]; then
     xml=""
     # we know we are being piped results
     IFS=$delim

--- a/clients/send_nrdp.sh
+++ b/clients/send_nrdp.sh
@@ -224,7 +224,7 @@ fi
 
  # If only url and token have been provided then it is assumed that data is being piped
 ########################
-if [[ ! $host && ! $State ]]; then
+if [[ ! $host && ! $State && ! $file ]]; then
     xml=""
     # we know we are being piped results
     IFS=$delim


### PR DESCRIPTION
`send_nrdp.py`
- Fixed setup function that was not working for piped results as the xml string was missing `</checkresults>`
  - Resovles the STDIN portion of issue https://github.com/NagiosEnterprises/nrdp/issues/16
- Added file argument to allow XML results to be read from file
  - Resovles the FILE portion of issue https://github.com/NagiosEnterprises/nrdp/issues/16
- Replaced optparse with argparse so help text can include newline characters, allowing for better formatting
  - This allows the help text to display an XML example
- Fixed setup function that was not working with arguments when run as a cron job or if being used as a nagios command like obsessive compulsive ... `if not sys.stdin.isatty():` was the reason why.
  - Resolves issue https://github.com/NagiosEnterprises/nrdp/issues/21
- Made sure url ends with a / before posting
  - Resolves issue https://github.com/NagiosEnterprises/nrdp/issues/15

`send_nrdp.sh`
- Fixed script not working with arguments when run as a cron job or if being used as a nagios command like obsessive compulsive  ... `if [ ! -t 0 ]` was the reason why.
  - Resolves issue https://github.com/NagiosEnterprises/nrdp/issues/19