### PR TITLE
Fix for deprecation notice in PHP8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+2.0.6 - xx/xx/xxxx
+------------------
+- Fixes for deprecations in PHP 8.2
+
 2.0.5 - 10/14/2021
 ------------------
 - Updated jQuery to version 3.6.0 -JO

--- a/server/plugins/nagioscorepassivecheck/nagioscorepassivecheck.inc.php
+++ b/server/plugins/nagioscorepassivecheck/nagioscorepassivecheck.inc.php
@@ -222,7 +222,7 @@ function nrdp_write_check_output_to_cmd($hostname, $servicename, $state, $output
     $check_result_contents .= "early_timeout=1\n";
     $check_result_contents .= "exited_ok=1\n";
     $check_result_contents .= "return_code={$state}\n";
-    $check_result_contents .= "output=${output}\\n\n";
+    $check_result_contents .= "output={$output}\\n\n";
 
     // put check result into the check file    
     file_put_contents($check_file, $check_result_contents);


### PR DESCRIPTION
When using PHP8.2 for the server the message "Using ${var} in strings is deprecated, use {$var} instead" is logged when submitting passive checks