### PR TITLE
Fix: Don't allow tabs in result contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+2.0.6 - XX/XX/2024
+------------------
+- Make sure tabs aren't mistakenly added to the output file of nrdp_write_check_output_to_cmd - (tsadpbb)
+
 2.0.5 - 10/14/2021
 ------------------
 - Updated jQuery to version 3.6.0 -JO

--- a/server/plugins/nagioscorepassivecheck/nagioscorepassivecheck.inc.php
+++ b/server/plugins/nagioscorepassivecheck/nagioscorepassivecheck.inc.php
@@ -224,6 +224,8 @@ function nrdp_write_check_output_to_cmd($hostname, $servicename, $state, $output
     $check_result_contents .= "return_code={$state}\n";
     $check_result_contents .= "output=${output}\\n\n";
 
+    $check_result_contents = str_replace("\t", " ", $check_result_contents);
+
     // put check result into the check file    
     file_put_contents($check_file, $check_result_contents);
 


### PR DESCRIPTION
process_perdata.pl in pnp4nagios will split lines using the `\t` character. Therefore, if someone puts a tab character in the perf data. Then when the file is processed by nagios, it will harm the function `process_perfdata_file`. This change ensures that the tab character isn't mistakenly added.